### PR TITLE
Removed reference to non-existing file "proxyaudiomixer.h"

### DIFF
--- a/src/peerconnectionfactory.cc
+++ b/src/peerconnectionfactory.cc
@@ -11,7 +11,6 @@
 
 #include "common.h"
 
-#include "proxyaudiomixer.h"
 #include "webrtc/api/audio/audio_mixer.h"
 #include "webrtc/api/test/fakeaudiocapturemodule.h"
 


### PR DESCRIPTION
Received the following error:

```
[ 68%] Building CXX object CMakeFiles/wrtc.dir/src/peerconnectionfactory.cc.o
/Users/mcp-pro/Sources/saltim-load-testbed-core/without-electron-testbed/node_modules/wrtc/src/peerconnectionfactory.cc:14:10: fatal error:
      'proxyaudiomixer.h' file not found
#include "proxyaudiomixer.h"
         ^~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/wrtc.dir/src/peerconnectionfactory.cc.o] Error 1
make[1]: *** [CMakeFiles/wrtc.dir/all] Error 2
make: *** [all] Error 2
Build failed
```

I "fixed" this by removing the header which references a missing file. It appears to work for my use-case but maybe It doesn't it all paths. The proper fix is probably add the missing file. Not sure if you forgot to add the file to the repo.

Cheers for the work your putting in BTW.