### PR TITLE
Implement DtlsSrtpKeyAgreement configuration

### DIFF
--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -53,6 +53,7 @@ PeerConnection::PeerConnection(webrtc::PeerConnectionInterface::IceServers iceSe
 
   webrtc::PeerConnectionInterface::RTCConfiguration configuration;
   configuration.servers = iceServerList;
+  configuration.enable_dtls_srtp = rtc::Optional<bool>(false);
 
   // TODO(mroberts): Read `factory` (non-standard) from RTCConfiguration?
   _factory = PeerConnectionFactory::GetOrCreateDefault();

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -44,7 +44,7 @@ Nan::Persistent<Function> PeerConnection::constructor;
 // PeerConnection
 //
 
-PeerConnection::PeerConnection(webrtc::PeerConnectionInterface::IceServers iceServerList, bool enableDtlsSrtp)
+PeerConnection::PeerConnection(webrtc::PeerConnectionInterface::IceServers iceServerList, rtc::Optional<bool> enableDtlsSrtp)
   : loop(uv_default_loop()) {
   _createOfferObserver = new rtc::RefCountedObject<CreateOfferObserver>(this);
   _createAnswerObserver = new rtc::RefCountedObject<CreateAnswerObserver>(this);
@@ -53,7 +53,7 @@ PeerConnection::PeerConnection(webrtc::PeerConnectionInterface::IceServers iceSe
 
   webrtc::PeerConnectionInterface::RTCConfiguration configuration;
   configuration.servers = iceServerList;
-  configuration.enable_dtls_srtp = rtc::Optional<bool>(enableDtlsSrtp);
+  configuration.enable_dtls_srtp = enableDtlsSrtp;
 
   // TODO(mroberts): Read `factory` (non-standard) from RTCConfiguration?
   _factory = PeerConnectionFactory::GetOrCreateDefault();
@@ -590,7 +590,7 @@ NAN_METHOD(PeerConnection::New) {
     }
   }
 
-  bool enableDtlsSrtp = true;
+  rtc::Optional<bool> enableDtlsSrtp = rtc::Optional<bool>();
 
   // Check if we have a constraints object
   if (info[1]->IsObject()) {
@@ -628,7 +628,7 @@ NAN_METHOD(PeerConnection::New) {
               String::Utf8Value _manKey(manKey);
               std::string manStrKey = std::string(*_manKey);
 
-              if (manStrKey == "DtlsSrtpKeyAgreement") enableDtlsSrtp = manValue->BooleanValue();
+              if (manStrKey == "DtlsSrtpKeyAgreement") enableDtlsSrtp = rtc::Optional<bool>(manValue->BooleanValue());
             }
           }
         }

--- a/src/peerconnection.cc
+++ b/src/peerconnection.cc
@@ -53,7 +53,7 @@ PeerConnection::PeerConnection(webrtc::PeerConnectionInterface::IceServers iceSe
 
   webrtc::PeerConnectionInterface::RTCConfiguration configuration;
   configuration.servers = iceServerList;
-  configuration.enable_dtls_srtp = rtc::Optional<bool>(enableDtlSrtp);
+  configuration.enable_dtls_srtp = rtc::Optional<bool>(false);
 
   // TODO(mroberts): Read `factory` (non-standard) from RTCConfiguration?
   _factory = PeerConnectionFactory::GetOrCreateDefault();

--- a/src/peerconnection.h
+++ b/src/peerconnection.h
@@ -172,7 +172,7 @@ class PeerConnection
         ICE_GATHERING_STATE_CHANGE
   };
 
-  explicit PeerConnection(webrtc::PeerConnectionInterface::IceServers iceServerList);
+  explicit PeerConnection(webrtc::PeerConnectionInterface::IceServers iceServerList, bool enableDtlSrtp);
   ~PeerConnection();
 
   //

--- a/src/peerconnection.h
+++ b/src/peerconnection.h
@@ -172,7 +172,7 @@ class PeerConnection
         ICE_GATHERING_STATE_CHANGE
   };
 
-  explicit PeerConnection(webrtc::PeerConnectionInterface::IceServers iceServerList, bool enableDtlSrtp);
+  explicit PeerConnection(webrtc::PeerConnectionInterface::IceServers iceServerList, rtc::Optional<bool> enableDtlsSrtp);
   ~PeerConnection();
 
   //


### PR DESCRIPTION
I have a use case which involves the `DtlsSrtpKeyAgreement` parameter. As such I've added it.

`DtlsSrtpKeyAgreement` according to the WebRTC on the browsers can be placed in either  `optional` or `mandatory` constraints. Optional specifies it is the preferred value if it can be honoured. Where as `mandatory` states it is a requirement.

I have only added it to node-webrtc in the case of mandatory.

e.g.
```
pc = new RTCPeerConnection({
			iceServers: [
				{ url: `stun:${turnHostname}:3478` },
				{ url: `turn:${turnHostname}:3478`, username: turnUsername, credential: turnPassword }
			]
		}, {
			mandatory: [
				{ DtlsSrtpKeyAgreement: false }
			]
		});
```