### PR TITLE
Implemented reading audio from file

### DIFF
--- a/lib/fileaudiodevicefactory.js
+++ b/lib/fileaudiodevicefactory.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var _webrtc = require('./binding');
+
+module.exports = new _webrtc.FileAudioDeviceFactory();

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,4 +2,5 @@ exports.RTCIceCandidate       = require('./icecandidate');
 exports.RTCPeerConnection     = require('./peerconnection');
 exports.RTCSessionDescription = require('./sessiondescription');
 exports.MediaDevices          = require('./mediadevices');
+exports.MediaDevices          = require('./fileaudiodevicefactory.js');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,5 +2,5 @@ exports.RTCIceCandidate       = require('./icecandidate');
 exports.RTCPeerConnection     = require('./peerconnection');
 exports.RTCSessionDescription = require('./sessiondescription');
 exports.MediaDevices          = require('./mediadevices');
-exports.MediaDevices          = require('./fileaudiodevicefactory.js');
+exports.FileAudioDeviceFactory = require('./fileaudiodevicefactory');
 

--- a/scripts/download-webrtc-libraries-and-headers.js
+++ b/scripts/download-webrtc-libraries-and-headers.js
@@ -57,7 +57,7 @@ function computeUrl(options) {
     win32: 'win'
   }[options.platform] || options.platform;
   var extension = platform === 'win' ? 'zip' : 'tar.gz';
-  return 'https://github.com/aisouard/libwebrtc/releases/download/v1.0.0/libwebrtc-1.0.0-'
+  return 'https://s3-eu-west-1.amazonaws.com/com.saltdna.apps/libwebrtc/libwebrtc-1.0.0-file-audio-'
     + platform + '-' + options.arch + '.' + extension;
 }
 

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -12,6 +12,7 @@
 #include "rtcstatsresponse.h"
 #include "peerconnection.h"
 #include "peerconnectionfactory.h"
+#include "fileaudiodevicefactory.h"
 #include "mediadevices.h"
 #include "mediastreamtrack.h"
 #include "mediastream.h"
@@ -24,6 +25,7 @@ void dispose(void*) {
 }
 
 void init(Handle<Object> exports) {
+  node_webrtc::FileAudioDeviceFactory::Init(exports);
   node_webrtc::PeerConnectionFactory::Init(exports);
   node_webrtc::PeerConnection::Init(exports);
   node_webrtc::DataChannel::Init(exports);

--- a/src/fileaudiodevicefactory.cc
+++ b/src/fileaudiodevicefactory.cc
@@ -7,6 +7,7 @@
 
 using node_webrtc::FileAudioDeviceFactory;
 using v8::FunctionTemplate;
+using v8::Function;
 using v8::Handle;
 using v8::Local;
 using v8::Object;

--- a/src/fileaudiodevicefactory.cc
+++ b/src/fileaudiodevicefactory.cc
@@ -3,36 +3,16 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 #include "fileaudiodevicefactory.h"
 
-#include "common.h"
-#include "mediastream.h"
-#include "create-offer-observer.h"
 #include "webrtc/modules/audio_device/dummy/file_audio_device_factory.h"
 
-#include <iostream>
-
 using node_webrtc::FileAudioDeviceFactory;
-using v8::External;
-using v8::Function;
 using v8::FunctionTemplate;
 using v8::Handle;
-using v8::Integer;
 using v8::Local;
-using v8::Number;
 using v8::Object;
 using v8::String;
-using v8::Uint32;
-using v8::Value;
 
 Nan::Persistent<Function> FileAudioDeviceFactory::constructor;
-
-// FileAudioDeviceFactory constructor/destructor
-/*FileAudioDeviceFactory::FileAudioDeviceFactory() {
-}
-
-FileAudioDeviceFactory::~FileAudioDeviceFactory() {
-  TRACE_CALL;
-  TRACE_END;
-}*/
 
 // NodeJS Wrapping
 NAN_METHOD(FileAudioDeviceFactory::New) {
@@ -51,10 +31,10 @@ NAN_METHOD(FileAudioDeviceFactory::New) {
 
 NAN_METHOD(FileAudioDeviceFactory::SetFilenamesToUse) {
   TRACE_CALL;
-  v8::String::Utf8Value inputArg(info[0]->ToString());
+  String::Utf8Value inputArg(info[0]->ToString());
   std::string input = std::string(*inputArg);
 
-  v8::String::Utf8Value outputArg(info[1]->ToString());
+  String::Utf8Value outputArg(info[1]->ToString());
   std::string output = std::string(*outputArg);
 
   webrtc::FileAudioDeviceFactory::SetFilenamesToUse(input.c_str(), output.c_str());

--- a/src/fileaudiodevicefactory.cc
+++ b/src/fileaudiodevicefactory.cc
@@ -51,14 +51,13 @@ NAN_METHOD(FileAudioDeviceFactory::New) {
 
 NAN_METHOD(FileAudioDeviceFactory::SetFilenamesToUse) {
   TRACE_CALL;
-  /*
-  v8::String::Utf8Value inputArg(args[0]->ToString());
+  v8::String::Utf8Value inputArg(info[0]->ToString());
   std::string input = std::string(*inputArg);
 
-  v8::String::Utf8Value outputArg(args[1]->ToString());
+  v8::String::Utf8Value outputArg(info[1]->ToString());
   std::string output = std::string(*outputArg);
-  */
-  webrtc::FileAudioDeviceFactory::SetFilenamesToUse("/Users/mcp-pro/Downloads/input.raw", "/Users/mcp-pro/Downloads/output.raw");
+
+  webrtc::FileAudioDeviceFactory::SetFilenamesToUse(input.c_str(), output.c_str());
   TRACE_END;
 }
 

--- a/src/fileaudiodevicefactory.cc
+++ b/src/fileaudiodevicefactory.cc
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+#include "fileaudiodevicefactory.h"
+
+#include "common.h"
+#include "mediastream.h"
+#include "create-offer-observer.h"
+#include "webrtc/modules/audio_device/dummy/file_audio_device_factory.h"
+
+#include <iostream>
+
+using node_webrtc::FileAudioDeviceFactory;
+using v8::External;
+using v8::Function;
+using v8::FunctionTemplate;
+using v8::Handle;
+using v8::Integer;
+using v8::Local;
+using v8::Number;
+using v8::Object;
+using v8::String;
+using v8::Uint32;
+using v8::Value;
+
+Nan::Persistent<Function> FileAudioDeviceFactory::constructor;
+
+// FileAudioDeviceFactory constructor/destructor
+/*FileAudioDeviceFactory::FileAudioDeviceFactory() {
+}
+
+FileAudioDeviceFactory::~FileAudioDeviceFactory() {
+  TRACE_CALL;
+  TRACE_END;
+}*/
+
+// NodeJS Wrapping
+NAN_METHOD(FileAudioDeviceFactory::New) {
+  TRACE_CALL;
+
+  if (!info.IsConstructCall()) {
+    return Nan::ThrowTypeError("Use the new operator to construct the FileAudioDeviceFactory.");
+  }
+
+  FileAudioDeviceFactory* obj = new FileAudioDeviceFactory();
+  obj->Wrap(info.This());
+
+  TRACE_END;
+  info.GetReturnValue().Set(info.This());
+}
+
+NAN_METHOD(FileAudioDeviceFactory::SetFilenamesToUse) {
+  TRACE_CALL;
+  /*
+  v8::String::Utf8Value inputArg(args[0]->ToString());
+  std::string input = std::string(*inputArg);
+
+  v8::String::Utf8Value outputArg(args[1]->ToString());
+  std::string output = std::string(*outputArg);
+  */
+  webrtc::FileAudioDeviceFactory::SetFilenamesToUse("/Users/mcp-pro/Downloads/input.raw", "/Users/mcp-pro/Downloads/output.raw");
+  TRACE_END;
+}
+
+void FileAudioDeviceFactory::Init(Handle<Object> exports) {
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+  tpl->SetClassName(Nan::New("FileAudioDeviceFactory").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+  Nan::SetPrototypeMethod(tpl, "setFilenamesToUse", SetFilenamesToUse);
+
+  constructor.Reset(tpl->GetFunction());
+  exports->Set(Nan::New("FileAudioDeviceFactory").ToLocalChecked(), tpl->GetFunction());
+}

--- a/src/fileaudiodevicefactory.h
+++ b/src/fileaudiodevicefactory.h
@@ -1,23 +1,7 @@
 #ifndef __FILEAUDIODEVICEFACTORY_H__
 #define __FILEAUDIODEVICEFACTORY_H__
 
-#include <string>
-
-#include <node.h>
-#include <v8.h>
-#include <node_object_wrap.h>
-#include <uv.h>
-
-#include "webrtc/base/scoped_ref_ptr.h"
-#include "webrtc/api/peerconnectioninterface.h"
-#include "webrtc/api/mediastreaminterface.h"
-#include "peerconnectionfactory.h"
-
 #include "common.h"
-#include "nan.h"
-
-using namespace node;
-using namespace v8;
 
 namespace node_webrtc {
 
@@ -32,7 +16,7 @@ public:
   // NodeJS Wrapping
   // NodeJS Wrapping
   static void Init(v8::Handle<v8::Object> exports);
-  static Nan::Persistent<Function> constructor;
+  static Nan::Persistent<v8::Function> constructor;
   static NAN_METHOD(New);
 
   static NAN_METHOD(SetFilenamesToUse);

--- a/src/fileaudiodevicefactory.h
+++ b/src/fileaudiodevicefactory.h
@@ -1,0 +1,43 @@
+#ifndef __FILEAUDIODEVICEFACTORY_H__
+#define __FILEAUDIODEVICEFACTORY_H__
+
+#include <string>
+
+#include <node.h>
+#include <v8.h>
+#include <node_object_wrap.h>
+#include <uv.h>
+
+#include "webrtc/base/scoped_ref_ptr.h"
+#include "webrtc/api/peerconnectioninterface.h"
+#include "webrtc/api/mediastreaminterface.h"
+#include "peerconnectionfactory.h"
+
+#include "common.h"
+#include "nan.h"
+
+using namespace node;
+using namespace v8;
+
+namespace node_webrtc {
+
+class FileAudioDeviceFactory
+: public Nan::ObjectWrap {
+
+public:
+  // Class implementation
+  explicit FileAudioDeviceFactory() {};
+  ~FileAudioDeviceFactory() {};
+
+  // NodeJS Wrapping
+  // NodeJS Wrapping
+  static void Init(v8::Handle<v8::Object> exports);
+  static Nan::Persistent<Function> constructor;
+  static NAN_METHOD(New);
+
+  static NAN_METHOD(SetFilenamesToUse);
+};
+
+} // namespace node_webrtc
+
+#endif

--- a/src/peerconnectionfactory.cc
+++ b/src/peerconnectionfactory.cc
@@ -13,7 +13,6 @@
 
 #include "webrtc/api/audio/audio_mixer.h"
 #include "webrtc/api/test/fakeaudiocapturemodule.h"
-#include "webrtc/modules/audio_device/dummy/file_audio_device_factory.h"
 
 using node_webrtc::PeerConnectionFactory;
 using v8::External;
@@ -123,7 +122,6 @@ void PeerConnectionFactory::Dispose() {
 
 void PeerConnectionFactory::Init(Handle<Object> exports) {
   uv_mutex_init(&_lock);
-  webrtc::FileAudioDeviceFactory::SetFilenamesToUse("/Users/mcp-pro/Downloads/input.raw", "/Users/mcp-pro/Downloads/output.raw");
 
   bool result;
   result = rtc::InitializeSSL();

--- a/src/peerconnectionfactory.cc
+++ b/src/peerconnectionfactory.cc
@@ -13,6 +13,7 @@
 
 #include "webrtc/api/audio/audio_mixer.h"
 #include "webrtc/api/test/fakeaudiocapturemodule.h"
+#include "webrtc/modules/audio_device/dummy/file_audio_device_factory.h"
 
 using node_webrtc::PeerConnectionFactory;
 using v8::External;
@@ -55,10 +56,10 @@ PeerConnectionFactory::PeerConnectionFactory(rtc::scoped_refptr<webrtc::AudioDev
   assert(result);
 
 
-  adm = FakeAudioCaptureModule::Create();
+  // adm = FakeAudioCaptureModule::Create();
 
   _decoderFactory = new NodeDecoderFactory();
-  _factory = webrtc::CreatePeerConnectionFactory(_workerThread.get(), _signalingThread.get(), adm,
+  _factory = webrtc::CreatePeerConnectionFactory(_workerThread.get(), _signalingThread.get(), nullptr,
           nullptr, _decoderFactory);
 
   assert(_factory);
@@ -122,6 +123,7 @@ void PeerConnectionFactory::Dispose() {
 
 void PeerConnectionFactory::Init(Handle<Object> exports) {
   uv_mutex_init(&_lock);
+  webrtc::FileAudioDeviceFactory::SetFilenamesToUse("/Users/mcp-pro/Downloads/input.raw", "/Users/mcp-pro/Downloads/output.raw");
 
   bool result;
   result = rtc::InitializeSSL();


### PR DESCRIPTION
Implemented the ability to use audio file as input instead of microphone. This could be useful for load testing TURN servers etc.

This was implemented using the internal `FileAudioDeviceFactory` of WebRTC, it requires libwebrtc to be recompiled with `rtc_use_dummy_audio_file_devices=true`. Which can be achieved by following these instructions https://github.com/aisouard/libwebrtc/issues/53#issuecomment-333335384. I have prebuilt libwebrtc for OSX and Linux, it still needs done for Windows 32-bit and Windows 64-bit. (Im unlikely to get around to this anytime soon, but if its the only thing stopping the PR being accepted Ill try to).

In order for this functionality to work, the following needs to be executed (As early as possible):
```
wrtc.FileAudioDeviceFactory.setFilenamesToUse(inputPath,outputPath)
```
Unfortunately it is a global setting, this is because the WebRTC uses it as a global setting as well. It is also supposed to support writing the output to a file as well, although it appears to be non-functioning.

The "correct" web way for this feature to be implemented is to use `AudioContext.createMediaStreamSource`. However there is no AudioContext in node and the polyfill libraries don't support `AudioContext.createMediaStreamSource`, unsurprisingly.

This PR removes the DummyAudioDevice, Im not sure what lead to its original conclusion. When just passing in `nullptr`, I had microphone and speaker working. Now with the FileAudioDevice, it will be silent unless a file is passed in. Maybe we should remove the FileAudioDevice classes from WebRTC, and put them in node-webrtc, that way we might get away without having to recompile for `rtc_use_dummy_audio_file_devices`.

